### PR TITLE
fix: correct AI agent service configuration paths

### DIFF
--- a/src/modules/consultations/services/ai-agent.service.ts
+++ b/src/modules/consultations/services/ai-agent.service.ts
@@ -107,10 +107,10 @@ export class AIAgentService {
     private readonly auditService: AuditService,
     private readonly aiTokenService: AITokenService,
   ) {
-    this.aiAgentUrl = this.configService.get<string>('AI_DIAGNOSIS_URL') || 'http://localhost:8000';
-    this.apiKey = this.configService.get<string>('AI_DIAGNOSIS_API_KEY') || '';
-    this.serviceName = this.configService.get<string>('AI_SERVICE_NAME') || 'tenderly-backend';
-    this.requestTimeout = this.configService.get<number>('AI_DIAGNOSIS_TIMEOUT') || 30000;
+    this.aiAgentUrl = this.configService.get<string>('ai.diagnosis.baseUrl') || 'http://localhost:8000';
+    this.apiKey = this.configService.get<string>('ai.diagnosis.apiKey') || '';
+    this.serviceName = this.configService.get<string>('ai.diagnosis.serviceName') || 'tenderly-backend';
+    this.requestTimeout = this.configService.get<number>('ai.diagnosis.timeout') || 30000;
     
     this.logger.log(`AI Agent Service initialized with URL: ${this.aiAgentUrl}, API Key: ${this.apiKey ? 'configured' : 'not configured'}, Service Name: ${this.serviceName}`);
     


### PR DESCRIPTION
- Fix configService.get() to use nested paths (ai.diagnosis.*)
- Change from direct env vars to proper config structure
- Resolves AI service fallback issues by proper config access
- Environment variables now properly loaded from Railway config

Related environment variables set in Railway:
- AI_DIAGNOSIS_URL
- AI_DIAGNOSIS_API_KEY
- AI_DIAGNOSIS_SECRET_KEY
- AI_SERVICE_NAME
- AI_DIAGNOSIS_TIMEOUT